### PR TITLE
#16 Feat: 본문 정보 유무에 따른 태그 부여 기능 - 본문 유

### DIFF
--- a/service/content_extractor.py
+++ b/service/content_extractor.py
@@ -1,0 +1,106 @@
+import re
+from bs4 import BeautifulSoup
+import html2text
+
+class ContentExtractor:
+    """
+    url과 html을 모두 전달받은 경우 html에서 중요한 내용만 추출  
+    - 특정 사이트: html 요소를 지정해서 추출 및 텍스트 변환
+    - 나머지 사이트: 바로 텍스트로 변환
+    """
+    def __init__(self, html_content):   # extract한 html을 텍스트로 변환 준비
+        self.html_content = html_content
+        self.soup = BeautifulSoup(html_content, 'html.parser')
+        self.text_maker = html2text.HTML2Text()
+        self.text_maker.ignore_links = True # 링크는 무시
+    
+    
+    def extract_youtube(self):
+        elements = []
+        title = self.soup.find('yt-formatted-string', class_='style-scope ytd-watch-metadata')
+        content = self.soup.find('span', class_='yt-core-attributed-string--link-inherit-color')
+        
+        if title:
+            elements.append(str(title))
+        if content:
+            elements.append(str(content))
+        
+        return self._post_process(elements) if elements else "No content found in YouTube"
+
+
+    def extract_velog(self):
+        elements = []
+        title = self.soup.find('div', class_='head_wrapper')
+        content = self.soup.find('div', class_='sc-eGRUor gdnhbG atom-one')
+        
+        if title:
+            elements.append(str(title))
+        if content:
+            elements.append(str(content))
+        
+        return self._post_process(elements) if elements else "No content found in Velog"
+
+
+    def extract_okky(self):
+        elements = []
+        title = self.soup.find('title')
+        content = self.soup.find('div', {'contenteditable': 'false', 'class': 'ProseMirror remirror-editor remirror-a11y-dark'})
+        
+        if title:
+            elements.append(str(title))
+        if content:
+            elements.append(str(content))
+        
+        return self._post_process(elements) if elements else "No content found in Okky"
+    
+    
+    def extract_tistory(self):
+        elements = []
+        title = (
+            self.soup.find('title') or
+            self.soup.find('h2') or
+            self.soup.find('h1') or
+            self.soup.find('p', class_='txt_sub_tit')
+        )
+        content = (
+            self.soup.find('div', id='article-view') or
+            self.soup.find('div', class_='area_view') or
+            self.soup.find('div', class_='contents_style') or
+            self.soup.find('article', id='article')
+        )
+        
+        if title:
+            elements.append(str(title))
+        if content:
+            elements.append(str(content))
+        
+        return self._post_process(elements) if elements else "No content found in Tistory"
+    
+    
+    def extract_generic(self):
+        # 일반 사이트의 특정 콘텐츠 추출 (title, content)
+        title = self.soup.find('title')
+        if not title:
+            title = self.soup.find('meta', attrs={'name': 'description'}) or self.soup.find('meta', property='og:title')
+        title_text = title.get_text() if title else "Title not found"
+
+        content = self.soup.find('article') or self.soup.find('div', id='content') or \
+                self.soup.find('div', class_='post') or self.soup.find('body')
+        content_text = self.text_maker.handle(str(content)) if content else "Content not found"
+        
+        # 리스트 형태로 _post_process로 전달
+        return self._post_process([title_text, content_text])
+
+
+    def html_to_text(self):
+        # 특정 사이트 + 일반 사이트 전체 HTML을 텍스트로 변환
+        plain_text = self.text_maker.handle(self.html_content)
+        return self._post_process(plain_text)   
+    
+    
+    def _post_process(self, elements):
+        # 변환한 텍스트를 정규표현식으로 후처리
+        combined_text = ' '.join(elements)
+        combined_pattern = r"[^\w\s.,!?()]+|!\([^)]*\)|http\S+"
+        cleaned_text = re.sub(combined_pattern, "", combined_text)
+        return re.sub(r"\s+", " ", cleaned_text).strip()

--- a/service/content_extractor.py
+++ b/service/content_extractor.py
@@ -8,99 +8,118 @@ class ContentExtractor:
     - 특정 사이트: html 요소를 지정해서 추출 및 텍스트 변환
     - 나머지 사이트: 바로 텍스트로 변환
     """
-    def __init__(self, html_content):   # extract한 html을 텍스트로 변환 준비
-        self.html_content = html_content
-        self.soup = BeautifulSoup(html_content, 'html.parser')
-        self.text_maker = html2text.HTML2Text()
-        self.text_maker.ignore_links = True # 링크는 무시
+    def __preprocess(self, html_content):   
+        soup = BeautifulSoup(html_content, 'html.parser')
+        text_maker = html2text.HTML2Text()
+        text_maker.ignore_links = True # 링크는 무시
+        return soup, text_maker
     
     
-    def extract_youtube(self):
-        elements = []
-        title = self.soup.find('yt-formatted-string', class_='style-scope ytd-watch-metadata')
-        content = self.soup.find('span', class_='yt-core-attributed-string--link-inherit-color')
+    def extract_youtube(self, html_content):
+        soup, _ = self.__preprocess(html_content)
         
-        if title:
-            elements.append(str(title))
-        if content:
-            elements.append(str(content))
+        title = soup.find('yt-formatted-string', class_='style-scope ytd-watch-metadata')
+        content = soup.find('span', class_='yt-core-attributed-string--link-inherit-color')
         
-        return self._post_process(elements) if elements else "No content found in YouTube"
+        return title if title else None, content if content else None
+    
 
+    def extract_velog(self, html_content):
+        soup, _ = self.__preprocess(html_content)
+        
+        title = soup.find('div', class_='head_wrapper')
+        content = soup.find('div', class_='sc-eGRUor gdnhbG atom-one')
+        
+        return title if title else None, content if content else None
+    
 
-    def extract_velog(self):
-        elements = []
-        title = self.soup.find('div', class_='head_wrapper')
-        content = self.soup.find('div', class_='sc-eGRUor gdnhbG atom-one')
+    def extract_okky(self, html_content):
+        soup, _ = self.__preprocess(html_content)
         
-        if title:
-            elements.append(str(title))
-        if content:
-            elements.append(str(content))
+        title = soup.find('title')
+        content = soup.find('div', {
+            'contenteditable': 'false', 
+            'class': 'ProseMirror remirror-editor remirror-a11y-dark'
+        })
         
-        return self._post_process(elements) if elements else "No content found in Velog"
-
-
-    def extract_okky(self):
-        elements = []
-        title = self.soup.find('title')
-        content = self.soup.find('div', {'contenteditable': 'false', 'class': 'ProseMirror remirror-editor remirror-a11y-dark'})
-        
-        if title:
-            elements.append(str(title))
-        if content:
-            elements.append(str(content))
-        
-        return self._post_process(elements) if elements else "No content found in Okky"
+        return title if title else None, content if content else None
     
     
-    def extract_tistory(self):
-        elements = []
+    def extract_tistory(self, html_content):
+        soup, _ = self.__preprocess(html_content)
+        
         title = (
-            self.soup.find('title') or
-            self.soup.find('h2') or
-            self.soup.find('h1') or
-            self.soup.find('p', class_='txt_sub_tit')
+            soup.find('title') or
+            soup.find('h2') or
+            soup.find('h1') or
+            soup.find('p', class_='txt_sub_tit')
         )
         content = (
-            self.soup.find('div', id='article-view') or
-            self.soup.find('div', class_='area_view') or
-            self.soup.find('div', class_='contents_style') or
-            self.soup.find('article', id='article')
+            soup.find('div', id='article-view') or
+            soup.find('div', class_='area_view') or
+            soup.find('div', class_='contents_style') or
+            soup.find('article', id='article')
         )
         
-        if title:
-            elements.append(str(title))
-        if content:
-            elements.append(str(content))
-        
-        return self._post_process(elements) if elements else "No content found in Tistory"
+        return title if title else None, content if content else None
     
     
-    def extract_generic(self):
-        # 일반 사이트의 특정 콘텐츠 추출 (title, content)
-        title = self.soup.find('title')
-        if not title:
-            title = self.soup.find('meta', attrs={'name': 'description'}) or self.soup.find('meta', property='og:title')
-        title_text = title.get_text() if title else "Title not found"
-
-        content = self.soup.find('article') or self.soup.find('div', id='content') or \
-                self.soup.find('div', class_='post') or self.soup.find('body')
-        content_text = self.text_maker.handle(str(content)) if content else "Content not found"
+    def extract_generic(self, html_content):
+        # 특정되지 않은 일반 사이트의 특정 콘텐츠 추출 (title, content)
+        soup, _ = self.__preprocess(html_content)
         
-        # 리스트 형태로 _post_process로 전달
-        return self._post_process([title_text, content_text])
+        title = (
+            soup.find('title') or 
+            soup.find('meta', attrs={'name': 'description'}) or 
+            soup.find('meta', property='og:title') or
+            soup.find('h1')
+        )
+        content = (
+            soup.find('article') or 
+            soup.find('div', id='content') or 
+            soup.find('div', class_='post') or 
+            soup.find('main') or
+            soup.find('body')
+        )
+        
+        return title if title else None, content if content else None
 
 
-    def html_to_text(self):
+    def html_to_text(self, title, content):
         # 특정 사이트 + 일반 사이트 전체 HTML을 텍스트로 변환
-        plain_text = self.text_maker.handle(self.html_content)
-        return self._post_process(plain_text)   
+        text_maker = html2text.HTML2Text()
+        text_maker.ignore_links = True
+        
+        title_text = text_maker.handle(str(title)) if title else None
+        content_text = text_maker.handle(str(content)) if content else None
+        
+        return title_text, content_text 
     
     
-    def _post_process(self, elements):
+    def _post_process(self, title_text, content_text):
         # 변환한 텍스트를 정규표현식으로 후처리
-        combined_text = ' '.join(elements)
-        combined_pattern = r"[^\w\s.,!?()]+|!\([^)]*\)|http\S+"
-        cleaned_text = re.sub(combined_pattern, "", combined_text)
-        return re.sub(r"\s+", " ", cleaned_text).strip()
+        def clean_text(text):
+            if text is None:
+                return None
+            combined_pattern = r"[^\w\s.,!?()]+|!\([^)]*\)|http\S+"
+            cleaned_text = re.sub(combined_pattern, "", text)
+            return re.sub(r"\s+", " ", cleaned_text).strip()
+        
+        return clean_text(title_text), clean_text(content_text)
+
+
+    def _format_result(self, title, content):
+        # 딕셔너리 형식으로 최종 반환
+        if title is None and content is None:
+            return None
+        return {
+            "title": title,
+            "content": content
+        }
+
+    def process_content(self, html_content, extract_method):
+        # 추출-처리 파이프라인 실행
+        title, content = extract_method(html_content)
+        title_text, content_text = self.html_to_text(title, content)
+        clean_title, clean_content = self._post_process(title_text, content_text)
+        return self._format_result(clean_title, clean_content)


### PR DESCRIPTION
<!--
## PR 체크리스트

PR을 제출하기 전에 아래의 체크리스트를 확인해주세요:

- [x] PR 제목을 관련 이슈 번호 + 이슈 이름으로 작성했는가
- [ ] commit convention이 프로젝트의 가이드라인에 맞는지 확인했습니다.
- [x] 새롭게 추가된 모든 기능에 대한 테스트를 완료했습니다.
- [ ] PR 설명에 작업 내용을 PR에 상세히 작성했습니다.
-->
## PR 유형

어떤 종류의 변경 사항인가요? (해당 사항에 모두 체크)

- [ ] 버그 수정 (기존 문제를 수정)
- [x] 기능 추가 (새로운 기능)
- [ ] 코드 스타일 수정 (포맷팅, 세미콜론 수정 등, 논리적 변경 없음)
- [ ] 리팩토링 (기능 수정 없이 코드 리팩토링)
- [ ] 문서 수정 (문서 추가 또는 수정)
- [ ] 테스트 추가 (기존 코드에 대한 테스트 추가)
- [ ] 빌드 또는 CI 관련 변경 사항

## PR 설명
본문 내용을 받아올 수 있는 경우 html에서 중요 내용만 추출하는 기능을 추가했습니다.

1. 지정된 사이트(html 구조를 아는): html에서 중요 내용을 지정해서 추출
    - Velog, Tistory, OKKY, Youtube
    - 원래 계획에 있었던 깃헙은 특정 태그를 지정하기 어려운 관계로 지정 사이트에서 제외했습니다.
2. 나머지 사이트: 최대한 불필요한 html을 필터링
    - 브런치스토리, 깃헙 등을 테스트해보았고 정상적으로 추출됩니다.

## 리뷰 요청
1. 지금은 html2text한 후 title, content를 리스트로 한꺼번에 반환하고 있는데 따로 해야 하는가? (버킷 링크에 title이 붙어야 하니까)
2. 특정 사이트에서 아무것도 찾지 못했을 때 지금처럼 'no content found'를 반환해도 되는가? 아니면 다른 방식으로 추출 실패를 알려야 하는가?

## 이슈
#16 

